### PR TITLE
Fix error reporting

### DIFF
--- a/prettierd_formatter.py
+++ b/prettierd_formatter.py
@@ -27,15 +27,22 @@ def format_with_prettierd(view_or_window, content, file_path):
         sublime.error_message(message)
         return None
 
-    cmd = [prettierd_path, "--stdin-filepath", file_path]
-    
+    cmd = [prettierd_path, file_path]
+
+    env = os.environ.copy()
+    # Force disable colored output.
+    # See: https://github.com/fsouza/prettierd/issues/790
+    env['NO_COLOR'] = '1'
+
     try:
         if sys.platform == 'win32':
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         else:
             startupinfo = None
-        process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=os.path.dirname(file_path), startupinfo=startupinfo)
+        process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE, cwd=os.path.dirname(file_path),
+                                   startupinfo=startupinfo, env=env)
         formatted_code, error = process.communicate(input=content.encode('utf-8'))
     except Exception as e:
         sublime.error_message("Failed to execute prettierd: " + str(e))

--- a/prettierd_formatter.py
+++ b/prettierd_formatter.py
@@ -44,7 +44,11 @@ def format_with_prettierd(view_or_window, content, file_path):
     if process.returncode == 0:
         return formatted_code.decode('utf-8')
     else:
-        error_message = error.decode('utf-8') if error.decode('utf-8') else "Unknown error"
+        error_message = error.decode('utf-8')
+        if not error_message:
+            error_message = formatted_code.decode('utf-8')
+        if not error_message:
+            error_message = "Unknown error"
         print(error_message)
         sublime.error_message("Error formatting the file with prettierd: " + error_message)
         return None


### PR DESCRIPTION
This fixes https://github.com/smastrom/sublime-prettierd-format/issues/8. I've also removed the `--stdin-filename` option, which doesn't seem to exist in `prettierd` anymore, and defined the `NO_COLOR` environment variable to prevent `prettierd` from emitting ANSI color codes.